### PR TITLE
Choose fs.exists* or path.exists*, depending on Node version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Clone the git repo:
 
 Then install the nodejs dependencies by running:
 
-    $ npm install -d bison log memcache sanitizer underscore websocket websocket-server
+    $ npm install -d bison log memcache sanitizer semver underscore websocket websocket-server
 
 Then start the server by running:
 

--- a/bin/r.js
+++ b/bin/r.js
@@ -15,7 +15,7 @@
 /*global readFile: true, process: false, Packages: false, print: false,
 console: false, java: false, module: false */
 
-var requirejs, require, define;
+var requirejs, require, define, semver = require('semver');
 (function (console, args, readFileFunc) {
 
     var fileName, env, fs, vm, path, exec, rhinoContext, dir, nodeRequire,
@@ -88,7 +88,11 @@ var requirejs, require, define;
         };
 
         exists = function (fileName) {
-            return path.existsSync(fileName);
+            // The path.existsSync function was renamed to fs.existsSync for Node 0.7.1 (unstable)
+            // onwards. This makes sure we use the correct one.
+            var fspathexistsSync = (semver.satisfies(process.version, '>=0.7.1')) ? fs.existsSync : path.existsSync;
+
+            return fspathexistsSync(fileName);
         };
 
 
@@ -2218,7 +2222,11 @@ var requirejs, require, define;
         context.loaded[moduleName] = false;
         context.scriptCount += 1;
 
-        if (path.existsSync(url)) {
+        // The path.existsSync function was renamed to fs.existsSync for Node 0.7.1 (unstable)
+        // onwards. This makes sure we use the correct one.
+        var fspathexistsSync = (semver.satisfies(process.version, '>=0.7.1')) ? fs.existsSync : path.existsSync;
+
+        if (fspathexistsSync(url)) {
             contents = fs.readFileSync(url, 'utf8');
 
             contents = req.makeNodeWrapper(contents);

--- a/package.json
+++ b/package.json
@@ -10,5 +10,6 @@
     , "websocket-server": ">0"
     , "sanitizer": ">0"
     , "memcache": ">0"
+    , "semver": ">0"
   }
 }

--- a/server/js/map.js
+++ b/server/js/map.js
@@ -9,10 +9,15 @@ var cls = require('./lib/class')
 module.exports = Map = cls.Class.extend({    
     init: function(filepath) {
     	var self = this;
-    
+
+        // The path.exists function was renamed to fs.exists for Node 0.7.1 (unstable)
+        // onwards. This makes sure we use the correct one.
+        var semver = require('semver');
+        var fspathexists = (semver.satisfies(process.version, '>=0.7.1')) ? fs.exists : path.exists;
+
     	this.isLoaded = false;
-    
-    	path.exists(filepath, function(exists) {
+
+    	fspathexists(filepath, function(exists) {
             if(!exists) {
                 log.error(filepath + " doesn't exist.");
                 return;


### PR DESCRIPTION
The "path.exists*" functions were renamed to "fs.exists*" from Node v0.7.1 (unstable) onwards, causing distracting messages to appear in our server log.

Copied the approach taken by Etherpad-lite to fix this, adjusted to suit:

  https://github.com/marcelklehr/etherpad-lite/commit/c01aaeefc1eb6a7796b17c6873d5718b73c1ac4d
