### PR TITLE
Initial code to run both client and server over the same port.

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -4,5 +4,6 @@
     "nb_players_per_world": 200,
     "nb_worlds": 5,
     "map_filepath": "./server/maps/world_server.json",
-    "metrics_enabled": false
+    "metrics_enabled": false,
+    "use_one_port": true
 }

--- a/server/js/main.js
+++ b/server/js/main.js
@@ -8,7 +8,7 @@ function main(config) {
         WorldServer = require("./worldserver"),
         Log = require('log'),
         _ = require('underscore'),
-        server = new ws.MultiVersionWebsocketServer(config.port),
+        server = new ws.MultiVersionWebsocketServer(config.port, config.use_one_port),
         metrics = config.metrics_enabled ? new Metrics(config) : null,
         worlds = [],
         lastTotalPlayers = 0,


### PR DESCRIPTION
Both client and server can now run over the same port.

Turned on/off by the 'use_one_port' boolean in server/config.json.

After starting the BQ server, connect to the port it's listening on with your browser.

  i.e.  http://server.example.org:8000/

The BQ server is now serving the client files through the same port, plus transparently taking care of the client shared/\* and config/\* files. (no need to touch them any more when running over one port)

This approach will probably suit developers and casual users very well, but may get in the way of multi-node setups. Change the 'use_one_port' setting in server/config.json to false to use the previous behaviour.
