### PR TITLE
Force older underscore module for now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   , "version": "0.0.1"
   , "private": false
   , "dependencies": {
-    "underscore": ">0"
+    "underscore": "<1.4.0"
     , "log": ">0"
     , "bison": ">0"
     , "websocket": ">0"


### PR DESCRIPTION
When using underscore version 1.4.0, TypeError exceptions are appearing in the console.log:

  ERROR uncaughtException: TypeError: Cannot read property 'forEach' of undefined

This works around the problem for now.
