### PR TITLE
Allow configuration of different production hosts

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -11,5 +11,6 @@
     "memcached_host": "127.0.0.1",
     "memcached_port": 11211,
     "game_servers": ["localhost"],
-    "server_name" : "localhost"
+    "server_name" : "localhost",
+    "production": "openshift"
 }

--- a/server/js/main.js
+++ b/server/js/main.js
@@ -1,5 +1,7 @@
 var fs = require('fs'),
-    Metrics = require('./metrics');
+    Metrics = require('./metrics'),
+    ProductionConfig = require('./productionconfig'),
+    _ = require('underscore');
 
 
 function main(config) {
@@ -13,9 +15,14 @@ function main(config) {
             log = new Log(Log.INFO); break;
     };
 
+    var production_config = new ProductionConfig(config);
+    console.info(production_config.getProductionSettings());
+    if(production_config.inProduction()) {
+        _.extend(config, production_config.getProductionSettings());
+    }
+
     var ws = require("./ws"),
         WorldServer = require("./worldserver"),
-        _ = require('underscore'),
         server = new ws.MultiVersionWebsocketServer(process.env.OPENSHIFT_NODEJS_PORT || config.port, config.use_one_port),
         metrics = config.metrics_enabled ? new Metrics(config) : null,
         worlds = [],

--- a/server/js/productionconfig.js
+++ b/server/js/productionconfig.js
@@ -1,0 +1,32 @@
+var cls = require('./lib/class');
+var ProductionConfig = {};
+
+ProductionConfig = cls.Class.extend({
+
+    init: function(config) {
+
+        this.config = config;
+        try {
+            this.production = require('../production_hosts/' + config.production + '.js');
+        }
+        catch(err) {
+            this.production = null;
+        }
+
+    },
+
+    inProduction: function() {
+        if(this.production !== null) {
+            return this.production.isActive();
+        }
+        return false;
+    },
+
+    getProductionSettings : function() {
+        if(this.inProduction()) {   
+            return this.production;
+        }
+    }
+});
+
+module.exports = ProductionConfig;

--- a/server/production_hosts/openshift.js
+++ b/server/production_hosts/openshift.js
@@ -1,0 +1,13 @@
+var config = {}
+
+
+config.ip = process.env.OPENSHIFT_NODEJS_IP;
+config.port = process.env.OPENSHIFT_NODEJS_PORT;
+config.redis_port = process.env.OPENSHIFT_REDIS_PORT
+config.redis_host = process.env.OPENSHIFT_REDIS_HOST
+
+config.isActive = function() {
+  return process.env.OPENSHIFT_NODEJS_IP !== undefined;
+}
+
+module.exports = config;


### PR DESCRIPTION
Currently, BrowserQuest supports running on Openshift. In the future, it may run on other PAAS providers, but it is setup to use only Openshift, if available. This PR allows specific configuration to be set for each known provider, including checking if BrowserQuest is running on that provider. The provider is specified in the config file.
