### PR TITLE
Made enemy stats window not show 'Level undefined' for non-enemies

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -157,17 +157,16 @@ define(['jquery', 'storage'], function($, Storage) {
                     x = ((sprite.animationData.idle_down.length-1)*sprite.width),
                     y = ((sprite.animationData.idle_down.row)*sprite.height);
                 $(el+' .name').text(name);
-                if(el === '#inspector'){
-                  //Show both Name and Level when mousing over the target
-                  $(el + ' .health').text("Level " + Types.getMobLevel(Types.getKindFromString(name)));
-                }
+
                 //Show how much Health creature has left. Currently does not work. The reason health doesn't currently go down has to do with the lines below down to initExpBar...
                 if(target.healthPoints){
-                    $(el + ' .health').text("Level " + Types.getMobLevel(Types.getKindFromString(name)));
                     $(el+" .health").css('width', Math.round(target.healthPoints/target.maxHp*100)+'%');
                 } else{
-                    $(el + ' .health').text("Level " + Types.getMobLevel(Types.getKindFromString(name)));
                     $(el+" .health").css('width', '100%');
+                }
+                var level = Types.getMobLevel(Types.getKindFromString(name));
+                if(level !== undefined) {
+                    $(el + ' .health').text("Level " + level);
                 }
 
                 $(el).fadeIn('fast');


### PR DESCRIPTION
This resolves issue #60
