### PR TITLE
Fixed display problems with enemy stats window

### DIFF
--- a/client/css/main.css
+++ b/client/css/main.css
@@ -180,39 +180,6 @@ footer, header, hgroup, menu, nav, section {
       width: 100%;
     }
 
-    #target{
-      font-family:'GraphicPixel';
-      color:#e3e3e3;
-      background-color:rgba(0, 0, 0, 0.43);
-      position: absolute;
-      top: 15px;
-      left: 15px;
-      width: 140px;
-      height: 70px;
-      margin-left: 0px;
-      padding: 4px;
-      display: none;
-      border-radius: 0 0 6px 0;
-    }
-    #target .details {
-      float: left;
-      margin-bottom: 8px;
-      width: 100px;
-      text-transform: capitalize;
-    }
-    #target .name {
-      float: left;
-      margin-bottom: 8px;
-      text-transform: capitalize;
-    }
-    #target .health {
-      float: left;
-      height: 10px;
-      width: 100%;
-      background: red;
-      clear: left;
-    }
-
     #inspector {
       font-family:'GraphicPixel';
       color:#e3e3e3;
@@ -227,22 +194,25 @@ footer, header, hgroup, menu, nav, section {
       border-radius: 0 0 6px 0;
    }
     #inspector .details {
-      float: left;
-      magin-bottom: 8px
-      width: 100px;
+      margin-bottom: 8px;
       text-transform: capitalize;
     }
      #inspector .name {
-      float: left;
       margin-bottom: 8px;
       text-transform: capitalize;
     }
 
+   #inspector .level {
+      margin-bottom: 8px;
+      text-transform: capitalize;
+   }
+
    #inspector .health {
-      float: left;
-      height: 15px;
+      height: 10px;
       width: 100%;
+      background: red;
       clear: left;
+      margin-top: 8px;
     }
 
     #dropDialog {

--- a/client/index.html
+++ b/client/index.html
@@ -273,17 +273,11 @@ Mozilla presents an HTML5 mini-MMORPG by Little Workshop http://www.littleworksh
     			<div id="bubbles"></div>
      			<div id="expbar"></div>
      			<div id="textWindow"></div>
-    			<div id="target">
-                            <div class="headshot"><div></div></div>
-                            <div class="details">
-                                <div class="name"></div>
-                                <div class="health"></div>
-                            </div>
-                        </div>
     			<div id="inspector">
                     <div class="headshot"><div> </div></div>
                     <div class="details">
                         <div class="name"></div>
+                        <div class="level"></div>
                         <div class="health"></div>
                     </div>
                 </div>

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -147,12 +147,11 @@ define(['jquery', 'storage'], function($, Storage) {
         initTargetHud: function(){
             var self = this;
             var scale = self.game.renderer.getScaleFactor(),
-                healthMaxWidth = $("#target .health").width() - (12 * scale),
+                healthMaxWidth = $("#inspector .health").width() - (12 * scale),
                 timeout;
 
             this.game.player.onSetTarget(function(target, name, mouseover){
-                var el = '#target';
-                if(mouseover) el = '#inspector';
+                var el = '#inspector';
                 var sprite = target.sprite,
                     x = ((sprite.animationData.idle_down.length-1)*sprite.width),
                     y = ((sprite.animationData.idle_down.row)*sprite.height);
@@ -166,27 +165,23 @@ define(['jquery', 'storage'], function($, Storage) {
                 }
                 var level = Types.getMobLevel(Types.getKindFromString(name));
                 if(level !== undefined) {
-                    $(el + ' .health').text("Level " + level);
+                    $(el + ' .level').text("Level " + level);
+                }
+                else {
+                    $('#inspector .level').text('');
                 }
 
                 $(el).fadeIn('fast');
             });
 
             self.game.onUpdateTarget(function(target){
-                $("#target .health").css('width', Math.round(target.healthPoints/target.maxHp*100) + "%");
-                if(self.game.player.inspecting && self.game.player.inspecting.id === target.id){
-                    $("#inspector .health").css('width', Math.round(target.healthPoints/target.maxHp*100) + "%");
-                }
+                $("#inspector .health").css('width', Math.round(target.healthPoints/target.maxHp*100) + "%");
             });
 
             self.game.player.onRemoveTarget(function(targetId){
-                $('#target').fadeOut('fast');
-                $('#target .health').text('');
-                if(self.game.player.inspecting && self.game.player.inspecting.id === targetId){
-                    $('#inspector').fadeOut('fast');
-                    $('#inspector .health').text('');
-                    self.game.player.inspecting = null;
-                }
+                $('#inspector').fadeOut('fast');
+                $('#inspector .level').text('');
+                self.game.player.inspecting = null;
             });
         },
          initExpBar: function(){

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -2079,7 +2079,7 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
                 }
                 else if(this.lastHovered) {
                     this.lastHovered.setHighlight(null);
-                    if(this.timeout === undefined) {
+                    if(this.timeout === undefined && !this.player.hasTarget()) {
                         var self = this;
                         this.timeout = setTimeout(function(){
                             $('#inspector').fadeOut('fast');


### PR DESCRIPTION
This resolves issue #62.

I've removed the "target" div, and switched the references to it to use the "inspector" div. I've also cleaned up some of the styling issues, such as the health bar not using the full window, and the level number appearing on a separate line.
