### PR TITLE
Fix issue #118 ('a' and 'f' keys do not work in login form)

### DIFF
--- a/client/js/main.js
+++ b/client/js/main.js
@@ -424,12 +424,9 @@ define(['jquery', 'app', 'entrypoint'], function($, App, EntryPoint) {
                         app.showChat();
                     }
                 }
-                 else if(key === 16)
+                else if(key === 16)
                     game.pvpFlag = true;
-                else if(key === 27)
-                    app.hideDropDialog();
-               if (game.started && !$('#chatbox').hasClass('active'))
-                {
+                if (game.started && !$('#chatbox').hasClass('active')) {
                     pos = {
                         x: game.player.gridX,
                         y: game.player.gridY
@@ -631,21 +628,12 @@ define(['jquery', 'app', 'entrypoint'], function($, App, EntryPoint) {
                 var key = e.which,
                     $chat = $('#chatinput');
 
-                if($('#chatinput:focus').size() == 0 && $('#nameinput:focus').size() == 0) {
-                    if(key === 13) { // Enter
-                        if(game.ready) {
-                            $chat.focus();
-                            return false;
-                        }
-                    }
-                    if(key === 32) { // Space
-                        // game.togglePathingGrid();
-                        return false;
-                    }
-                    if(key === 70) { // F
-                        // game.toggleDebugInfo();
-                        return false;
-                    }
+                if(key === 13 && game.ready) { // Enter
+                    $chat.focus();
+                    return false;
+                }
+
+                if($('#chatinput:focus').size() == 0 && $('#nameinput:focus').size() == 0) {                    
                     if(key === 27) { // ESC
                         app.hideWindows();
                         _.each(game.player.attackers, function(attacker) {
@@ -653,15 +641,17 @@ define(['jquery', 'app', 'entrypoint'], function($, App, EntryPoint) {
                         });
                         return false;
                     }
-                    if(key === 65) { // a
-                        // game.player.hit();
-                        return false;
-                    }
-                } else {
-                    if(key === 13 && game.ready) {
-                        $chat.focus();
-                        return false;
-                    }
+
+                    // The following may be uncommented for debugging purposes.
+                    //
+                    // if(key === 32 && game.ready) { // Space
+                    //     game.togglePathingGrid();
+                    //     return false;
+                    // }
+                    // if(key === 70 && game.ready) { // F
+                    //     game.toggleDebugInfo();
+                    //     return false;
+                    // }
                 }
             });
 


### PR DESCRIPTION
These were apparently used for debugging purposes ('a' ran the attack animation, and 'f' shows the FPS). The actual functionality was commented out, but the 'return false' part was left in there, which prevented the default action from bubbling up properly.

Explanation for some of the other minor fixes:
- remove app.hideDropDialog(): This is not actually defined. More importantly, it's causing the other ESC key handler in this file from firing (search for the last occurrence of app.hideWindows), which closes any open dialogs (such as achievements or help).
- The event handler for 'a' that called game.player.hit (note: the call was commented out because it was for debugging purposes) was removed entirely since it conflicted with the WASD movement keys (so even if you were to uncomment it, it still wouldn't do anything). Besides, all it did was run the player's attack animation without actually attacking anything, even if you were standing next to someone - probably not terribly useful.
- Handler for the Enter key (key === 13) was present in both the if and else blocks (and was pretty much identical), so it was moved outside.
