### PR TITLE
Fixes issue #120 (privacy / legal notices overlap with form), and another issue with text getting cut off on the iPhone

### DIFF
--- a/client/css/main.css
+++ b/client/css/main.css
@@ -1089,7 +1089,7 @@ footer, header, hgroup, menu, nav, section {
         #character {height:21px;width:12px;margin:0 auto;background-position:-354px -12px;margin-top:15px;position:relative;display:none;}
         #character div {height:21px;width:12px;position:absolute;top:0;left:0;background-position:-366px -12px;opacity:1;}
         #character.disabled div {opacity:0;pointer-events:none;}
-        #parchment input {margin-top:10px; padding-bottom:5px; border-bottom:1px dashed #b2af9b; font-size:20px;-moz-animation:none;-webkit-animation:none;-o-animation:none;-ms-animation:none;color:#eee;}
+        #parchment input {margin-top:10px; padding-bottom:5px; border-bottom:1px dashed #b2af9b; font-size:14px;-moz-animation:none;-webkit-animation:none;-o-animation:none;-ms-animation:none;color:#eee;}
         #parchment.createcharacter input {margin-top:4px;height:15px;}
         .button {height:54px;width:204px;background-position:-500px -952px;margin:20px auto 0 auto;position:relative;background-size:844px;}
         .play, #create-new {font-size:16px;}


### PR DESCRIPTION
A couple really quick CSS changes to fix some minor issues.

For issue #120 (privacy / legal notices), basically just push the footer down another 30 pixels.

The other issue I noticed is that on the iPhone, text that appears within the Create New Character form fields gets cut off:

![issue](https://f.cloud.github.com/assets/766698/1170519/ed0b5f68-20df-11e3-849c-abf24c6ebbc0.PNG)

I made the height of those fields smaller in pull request #125, but didn't adjust the font size accordingly - my bad. Fixing this now by decreasing the font size.
