### PR TITLE
patch camera scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Ubuntu
 
     $ sudo apt-get update
     $ sudo apt-get upgrade
-    $ sudo apt-get install g++ make memcached libncurses5 redis-server git -y
+    $ sudo apt-get install g++ make memcached libncurses5 redis-server git curl -y
     $ curl -sL https://deb.nodesource.com/setup | sudo bash -
-    $ sudo apt-get install nodejs
+    $ sudo apt-get install nodejs -y
 
 Clone the git repo:
 

--- a/client/js/camera.js
+++ b/client/js/camera.js
@@ -13,7 +13,7 @@ define(function() {
         },
 
         rescale: function() {
-            var factor = this.renderer.mobile ? 1 : 2;
+            var factor = this.renderer.getScaleFactor();
 
             this.gridW = 15 * factor;
             this.gridH = 7 * factor;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "type": "git",
     "url": "https://github.com/browserquest/BrowserQuest.git"
   },
+  "license": "LicenseRef-LICENSE",
   "version": "0.0.1",
   "dependencies": {
     "bcrypt": ">=0",


### PR DESCRIPTION
I'm not sure why -- I assume it's a bug -- but the renderer could have a scale factor of 1, 2, or 3, and the camera only a scale factor of 1 or 2.

I'm assuming this was just a bug introduced somewhere along the lines, and not by design?
