### PR TITLE
move player through doorways so arrow keys and clicking works

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -959,12 +959,21 @@ function(InfoManager, BubbleManager, Renderer, Map, Animation, Sprite, AnimatedT
 
                     if(!self.player.hasTarget() && self.map.isDoor(x, y)) {
                         var dest = self.map.getDoorDestination(x, y);
+                        var desty = dest.y;
 
-                        self.player.setGridPosition(dest.x, dest.y);
+                        //push them off the door spot so they can use the
+                        //arrow keys and mouse to walk back in or out
+                        if (dest.orientation === Types.Orientations.UP) {
+                            desty--;
+                        } else if (dest.orientation === Types.Orientations.DOWN) {
+                            desty++;
+                        }
+
+                        self.player.setGridPosition(dest.x, desty);
                         self.player.nextGridX = dest.x;
-                        self.player.nextGridY = dest.y;
+                        self.player.nextGridY = desty;
                         self.player.turnTo(dest.orientation);
-                        self.client.sendTeleport(dest.x, dest.y);
+                        self.client.sendTeleport(dest.x, desty);
 
                         if(self.renderer.mobile && dest.cameraX && dest.cameraY) {
                             self.camera.setGridPosition(dest.cameraX, dest.cameraY);


### PR DESCRIPTION
This fixes the problem with not being able to click on doors or use your arrow keys once you've entered a door. It pushes the character one spot further into the room so arrow keys and clicking on the door spot work after you've moved through the doorway.
